### PR TITLE
Fix import controller and add Cliente model

### DIFF
--- a/Desktop/INTELIA LIMPIO 02/controllers/api/v1/import_controller.py
+++ b/Desktop/INTELIA LIMPIO 02/controllers/api/v1/import_controller.py
@@ -1,8 +1,9 @@
 
+from flask import Blueprint, request, jsonify, current_app
+from models import db
 from models.cliente import Cliente
 
 import_bp = Blueprint('import_bp', __name__, url_prefix='/api/v1/import')
-from flask import Blueprint
 
 @import_bp.route('/clientes', methods=['POST'])
 def import_clientes():

--- a/Desktop/INTELIA LIMPIO 02/models/__init__.py
+++ b/Desktop/INTELIA LIMPIO 02/models/__init__.py
@@ -1,0 +1,3 @@
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()

--- a/Desktop/INTELIA LIMPIO 02/models/cliente.py
+++ b/Desktop/INTELIA LIMPIO 02/models/cliente.py
@@ -1,0 +1,13 @@
+from . import db
+
+
+class Cliente(db.Model):
+    __tablename__ = "clientes"
+
+    id = db.Column(db.Integer, primary_key=True)
+    nombre = db.Column(db.String(255), nullable=False)
+    telefono = db.Column(db.String(50))
+    email = db.Column(db.String(255))
+
+    def __repr__(self):
+        return f"<Cliente {self.nombre}>"


### PR DESCRIPTION
## Summary
- clean up `import_controller.py` imports
- add simple SQLAlchemy setup under `models`
- implement `Cliente` model for imports

## Testing
- `python -m py_compile Desktop/INTELIA\ LIMPIO\ 02/controllers/api/v1/import_controller.py Desktop/INTELIA\ LIMPIO\ 02/models/cliente.py Desktop/INTELIA\ LIMPIO\ 02/models/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6856bddf9e308328ae55b88dbdc79da1