### PR TITLE
Remove secret key fallback

### DIFF
--- a/Desktop/INTELIA LIMPIO 02/controllers/api/v1/auth_controller.py
+++ b/Desktop/INTELIA LIMPIO 02/controllers/api/v1/auth_controller.py
@@ -8,7 +8,8 @@ import hashlib
 
 bp = Blueprint("auth", __name__, url_prefix="/api/v1/auth")
 DB_PATH = get_db_path()
-SECRET_KEY = os.environ.get("INTELIA_SECRET_KEY", "INTELIA_SUPER_SECRETO")
+# Fail fast if the environment variable is missing
+SECRET_KEY = os.environ["INTELIA_SECRET_KEY"]
 
 @bp.route("/login", methods=["POST"])
 def login():

--- a/Desktop/INTELIA LIMPIO 02/utils/auth_utils.py
+++ b/Desktop/INTELIA LIMPIO 02/utils/auth_utils.py
@@ -3,7 +3,8 @@ import jwt
 import os
 from functools import wraps
 
-SECRET_KEY = os.environ.get("INTELIA_SECRET_KEY", "INTELIA_SUPER_SECRETO")
+# Fail fast if the environment variable is missing
+SECRET_KEY = os.environ["INTELIA_SECRET_KEY"]
 
 def token_required(f):
     @wraps(f)

--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ el objeto `report.json`.
 
 Con este set de roles y el prompt maestro tu agente de testing podrá comportarse como usuarios reales, descubrir errores incapaces de detectarse con pruebas puramente unitarias y entregar un informe listo para el equipo de desarrollo. ¡Listo para implementar!
 ```
+
+## Environment variables
+
+Set `INTELIA_SECRET_KEY` before running the application. This secret key is mandatory and used for signing authentication tokens.


### PR DESCRIPTION
## Summary
- remove fallback default in auth utils
- remove fallback default in API auth controller
- document that `INTELIA_SECRET_KEY` env var is required

## Testing
- `python -m py_compile "Desktop/INTELIA LIMPIO 02/utils/auth_utils.py" "Desktop/INTELIA LIMPIO 02/controllers/api/v1/auth_controller.py"`

------
https://chatgpt.com/codex/tasks/task_e_6856becff6a0832897dc87f25293527a